### PR TITLE
Added TL, SHORT and LONG methods

### DIFF
--- a/lib/parayaz.rb
+++ b/lib/parayaz.rb
@@ -25,6 +25,23 @@ module Parayaz
 
     (minus ? 'eksi ' : '') + text
   end
+  
+  # 35.00₺  70.00₺
+  # 5.0₺ 
+  def SHORT decimals=2
+    "%.#{decimals}f₺" % self
+  end
+  
+  # Copy of SHORT
+  def TL decimals=2
+    "%.#{decimals}f₺" % self
+  end
+  
+  # 20.0₺ (yirmiTL)
+  # 35.0₺ (otuzbeşTL)
+  def LONG decimals=2
+    "%s (%s)" % [self.SHORT(decimals), parayaz]
+  end
 
   private
   def say_1_digit_text(n)

--- a/spec/parayaz_spec.rb
+++ b/spec/parayaz_spec.rb
@@ -11,6 +11,24 @@ describe Parayaz do
     it 'should return: binbeşyüzkırkbirTL' do
       expect(1541.parayaz).to eq 'binbeşyüzkırkbirTL'
     end
+    
+    # testing SHORT and LONG methods
+    
+    it 'should return: 35.0₺' do
+      expect(35.SHORT(decimals=1)).to eq '35.0₺'
+    end
+    
+    it 'should return: 27.00₺' do
+      expect(27.SHORT(decimals=2)).to eq '27.00₺'
+    end
+    
+    it 'should return: 45.0₺ (kırkbeşTL)' do
+      expect(45.LONG(decimals=1)).to eq '45.0₺ (kırkbeşTL)'
+    end
+    
+    it 'should return: 70.00₺ (yetmişTL)' do
+      expect(70.LONG(decimals=2)).to eq '70.00₺ (yetmişTL)'
+    end
   end
 
   context 'Test float numbers' do
@@ -48,4 +66,5 @@ describe Parayaz do
       expect(-0.5.parayaz).to eq 'eksi ellikr.'
     end
   end
+  
 end


### PR DESCRIPTION
Added TL, SHORT and LONG methods to parayaz module.
With that methods you can simple do 35.TL for getting ’35.0₺’.

With LONG method, you will get ’35.0₺ (otuzbeşTL)’.

It’s not the best thing ever but why not?
