### PR TITLE
Fix Rational numbers bug

### DIFF
--- a/lib/parayaz.rb
+++ b/lib/parayaz.rb
@@ -2,7 +2,7 @@ require 'parayaz/version'
 
 module Parayaz
   def parayaz
-    number = self
+    number = self.to_f
     minus = number < 0
 
     number *= -1 if minus

--- a/spec/parayaz_spec.rb
+++ b/spec/parayaz_spec.rb
@@ -48,4 +48,19 @@ describe Parayaz do
       expect(-0.5.parayaz).to eq 'eksi ellikr.'
     end
   end
+
+  context 'Test Rational numbers' do
+    it 'should return eksi ikiTL' do
+      expect(Rational(-2, 1).parayaz).to eq 'eksi ikiTL'
+    end
+    it 'should return birTL,ellikr.' do
+      expect(Rational(3, 2).parayaz).to eq 'birTL,ellikr.'
+    end
+    it 'should return onTL' do
+      expect(Rational(10, 1).parayaz).to eq 'onTL'
+    end
+    it 'should return ellikr.' do
+      expect(Rational(1, 2).parayaz).to eq 'ellikr.'
+    end
+  end
 end


### PR DESCRIPTION
Problem:

``` ruby
number = Rational(1, 2)
number.parayaz # => "birTL"
```

As you can see this method does not work properly with Rational numbers.
By this change `parayaz` method will work as expected for Rational numbers. Also this change fix the problem on `Complex` numbers too. 
But I think representing money with Complex is not make sense because we can't talk about positive or negative complex numbers so if removing this method from `Complex` make sense for you, let me know and I'll handle it in separate pr.
